### PR TITLE
Account for initial null value

### DIFF
--- a/src/forty-datetime.coffee
+++ b/src/forty-datetime.coffee
@@ -131,7 +131,7 @@ angular.module('fortyDate', [])
       char_raw = el.value.replace(/\W/g, '').split('')
 
       insert_pos = pos-delimiter_cnt
-      if char_raw.indexOf('_') < insert_pos
+      if char_raw.indexOf('_') > -1 && char_raw.indexOf('_') < insert_pos
         insert_pos = char_raw.indexOf('_')
 
       # If we want to completely replace we pass null


### PR DESCRIPTION
If value is initially nothing, indexOf('_') comes back as -1. -1 is less than 0, so insert_pos is set to -1. This causes this issue:

initial placeholder: **/**/____    initial value: ""
enter "2"
value: 2_/**/__**
enter "2"
value: 32/**/__**
